### PR TITLE
Simplify routes

### DIFF
--- a/app/assets/javascripts/components/main/directives/component-card/component-card-view.html
+++ b/app/assets/javascripts/components/main/directives/component-card/component-card-view.html
@@ -3,9 +3,9 @@
   <div ng-if="!ctrl.editing" ng-include="'components/main/directives/component-card/partials/component-regular-view.html'"></div>
   <div ng-show="ctrl.isSelected">
     <section ng-if="ctrl.component.grades">
-      <gp-grade-card ng-repeat="grade in ctrl.component.grades" gp-course-ctrl="gpCourseCtrl" gp-component-ctrl="ctrl" gp-grade="grade" gp-editing="false"></gp-grade-card>
+      <gp-grade-card ng-repeat="grade in ctrl.component.grades" gp-component-ctrl="ctrl" gp-grade="grade" gp-editing="false"></gp-grade-card>
     </section>
-    <gp-grade-card ng-if="ctrl.addingGrade" gp-course-ctrl="gpCourseCtrl" gp-component-ctrl="ctrl" gp-editing="true"></gp-grade-card>
+    <gp-grade-card ng-if="ctrl.addingGrade" gp-component-ctrl="ctrl" gp-editing="true"></gp-grade-card>
     <div class="form-group col-md-2 col-xs-4 text-center add-course-button">
       <button id="newGradeButton{{ctrl.component.id}}" ng-if="!ctrl.addingGrade" ng-click="ctrl.showNewGrade()" type="button" class="btn btn-default pull-right">&plus; Add a grade</button>
     </div>

--- a/app/assets/javascripts/components/main/directives/component-card/componentCardCtrl.js
+++ b/app/assets/javascripts/components/main/directives/component-card/componentCardCtrl.js
@@ -4,13 +4,13 @@
   ComponentCardCtrl.$inject = ['$scope', '$resource', 'flash'];
 
   function ComponentCardCtrl($scope, $resource, flash) {
-    var Component = $resource('courses/:courseId/components/:componentId', {courseId: '@courseId', componentId: '@id', format: 'json' },
+    var Component = $resource('components/:componentId', {componentId: '@id', format: 'json' },
       {
         'delete': {method: 'DELETE'},
         'create': {method: 'POST'},
         'save': {method: 'PUT'}
       });
-    var Grade = $resource('courses/:courseId/components/:componentId/grades/:gradeId', {courseId: '@courseId', componentId: '@componentId', gradeId: '@id', format: 'json' },
+    var Grade = $resource('grades/:gradeId', {gradeId: '@id', format: 'json' },
       {
         'delete': {method: 'DELETE'},
         'create': {method: 'POST'},
@@ -39,7 +39,7 @@
 
     ctrl.getGrades = function () {
       if(ctrl.component.id) {
-        Grade.query({courseId: $scope.gpCourseCtrl.course.id, componentId: ctrl.component.id}, function (results) {
+        Grade.query({component_id: ctrl.component.id}, function (results) {
           ctrl.component.grades = results.sort(function (a,b) {
             return a.id - b.id;
           });
@@ -55,7 +55,7 @@
 
     ctrl.delete = function () {
       console.log('Deleting component with id: ' + ctrl.component.id);
-      ctrl.component.$delete({courseId: $scope.gpCourseCtrl.course.id, componentId: ctrl.component.id}, function(){
+      ctrl.component.$delete({componentId: ctrl.component.id}, function(){
         $scope.$destroy();}
       );
 
@@ -77,7 +77,7 @@
       ctrl.editing = false; // successful, so close dialog
 
       if(ctrl.component.id) { // This is an existing component if it already has an id; editing, not creating
-        ctrl.component.$save({courseId: $scope.gpCourseCtrl.course.id, componentId: ctrl.component.id},
+        ctrl.component.$save({componentId: ctrl.component.id},
           (function() {
             console.log('Updated component with id ' + ctrl.component.id);
           }),
@@ -85,7 +85,7 @@
         );
       }
       else { // This is a new component if it does not have an id
-        ctrl.component.courseId = $scope.gpCourseCtrl.course.id;
+        ctrl.component.course_id = $scope.gpCourseCtrl.course.id;
         Component.create(ctrl.component, (
           function (createdComponent) {
             // flash.success = "Component created successfully"

--- a/app/assets/javascripts/components/main/directives/course-card/courseCardCtrl.js
+++ b/app/assets/javascripts/components/main/directives/course-card/courseCardCtrl.js
@@ -10,7 +10,7 @@
         'create': {method: 'POST'},
         'save': {method: 'PUT'}
       });
-    var Component = $resource('/courses/:courseId/components/:componentId', { format: 'json' },
+    var Component = $resource('components/:componentId', { format: 'json' },
       {
         'delete': {method: 'DELETE'},
         'create': {method: 'POST'},
@@ -30,7 +30,7 @@
 
     ctrl.getComponents = function () {
       if(ctrl.course.id) {
-        Component.query({courseId: ctrl.course.id}, function (results) {
+        Component.query({course_id: ctrl.course.id}, function (results) {
           ctrl.course.components = results.sort(function (a,b) {
             return a.id - b.id;
           });

--- a/app/assets/javascripts/components/main/directives/grade-card/gradeCardCtrl.js
+++ b/app/assets/javascripts/components/main/directives/grade-card/gradeCardCtrl.js
@@ -4,7 +4,7 @@
   GradeCardCtrl.$inject = ['$scope', '$resource', 'flash'];
 
   function GradeCardCtrl($scope, $resource, flash) {
-    var Grade = $resource('courses/:courseId/components/:componentId/grades/:gradeId', {courseId: '@courseId', componentId: '@componentId', gradeId: '@id', format: 'json' },
+    var Grade = $resource('grades/:gradeId', {gradeId: '@id', format: 'json' },
       {
         'delete': {method: 'DELETE'},
         'create': {method: 'POST'},
@@ -15,8 +15,14 @@
     ctrl.editing = false;
 
     ctrl.init = function () {
-      ctrl.grade = $scope.gpGrade ? $scope.gpGrade : {};
-      ctrl.grade.fullScore = ctrl.grade.score + '/' + ctrl.grade.max;
+      if($scope.gpGrade) {
+        ctrl.grade = $scope.gpGrade;
+        ctrl.grade.fullScore = ctrl.grade.score + '/' + ctrl.grade.max;
+      }
+      else {
+        ctrl.grade = {};
+        ctrl.grade.fullScore = '';
+      }
       // ctrl.grade.id = $scope.gpGradeId;
       ctrl.editing = $scope.gpEditing;
     }
@@ -29,7 +35,7 @@
 
     ctrl.delete = function () {
       console.log('Deleting grade with id: ' + ctrl.grade.id);
-      ctrl.grade.$delete({courseId: $scope.gpCourseCtrl.course.id, componentId: $scope.gpComponentCtrl.component.id, gradeId: ctrl.grade.id}, function(){
+      ctrl.grade.$delete({gradeId: ctrl.grade.id}, function(){
         $scope.$destroy();}
       );
 
@@ -53,7 +59,7 @@
       ctrl.editing = false; // successful, so close dialog
 
       if(ctrl.grade.id) { // This is an existing grade if it already has an id; editing, not creating
-        ctrl.grade.$save({courseId: $scope.gpCourseCtrl.course.id, componentId: $scope.gpComponentCtrl.component.id, gradeId: ctrl.grade.id},
+        ctrl.grade.$save({gradeId: ctrl.grade.id},
           (function() {
             console.log('Updated grade with id ' + ctrl.grade.id);
           }),
@@ -61,8 +67,7 @@
         );
       }
       else { // This is a new grade if it does not have an id
-        ctrl.grade.courseId = $scope.gpCourseCtrl.course.id;
-        ctrl.grade.componentId = $scope.gpComponentCtrl.component.id;
+        ctrl.grade.component_id = $scope.gpComponentCtrl.component.id;
         Grade.create(ctrl.grade, (
           function (createdGrade) {
             // flash.success = "Grade created successfully"

--- a/app/assets/javascripts/components/main/directives/grade-card/gradeCardDirective.js
+++ b/app/assets/javascripts/components/main/directives/grade-card/gradeCardDirective.js
@@ -5,7 +5,6 @@
         restrict: 'E',
         templateUrl: 'components/main/directives/grade-card/grade-card-view.html',
         scope: {
-          gpCourseCtrl: '=',
           gpComponentCtrl: '=',
           gpGrade: '=',
           gpEditing: '='

--- a/app/controllers/components_controller.rb
+++ b/app/controllers/components_controller.rb
@@ -40,7 +40,7 @@ class ComponentsController < ApplicationController
 
   private
 		def component_params
-			params.require(:component).permit(:name, :weight)
+			params.require(:component).permit(:name, :weight, :course_id)
 		end
 
 end

--- a/app/controllers/grades_controller.rb
+++ b/app/controllers/grades_controller.rb
@@ -39,7 +39,7 @@ class GradesController < ApplicationController
 
   private
 		def grade_params
-			params.require(:grade).permit(:name, :score, :max)
+			params.require(:grade).permit(:name, :score, :max, :component_id)
 		end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,7 @@
 Rails.application.routes.draw do
   root 'home#index'
 
-  resources :courses, only: [:index, :show, :create, :update, :destroy] do
-    resources :components, only: [:index, :show, :create, :update, :destroy] do
-      resources :grades, only: [:index, :show, :create, :update, :destroy]
-    end
-  end
+  resources :courses
+  resources :components
+  resources :grades
 end


### PR DESCRIPTION
### Summary

Routes don't need to be nested. Only need to know the `id` of the parent.
This PR makes all resource routes (courses, components, grades) single level (no nesting).

Angular controller requests are more simplified (though still ugly) as a result.