### PR TITLE
Return all json with nested children

### DIFF
--- a/app/views/components/_component.json.jbuilder
+++ b/app/views/components/_component.json.jbuilder
@@ -1,1 +1,4 @@
-json.call(component, :id, :name, :weight)
+json.id component.id
+json.name component.name
+json.weight component.weight
+json.grades component.grades, partial: 'grades/grade', as: :grade

--- a/app/views/courses/_course.json.jbuilder
+++ b/app/views/courses/_course.json.jbuilder
@@ -1,1 +1,4 @@
-json.call(course, :id, :name, :code, :user_id)
+json.id course.id
+json.name course.name
+json.code course.code
+json.components course.components, partial: 'components/component', as: :component

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -21,6 +21,19 @@ class CoursesControllerTest < ActionController::TestCase
     assert_equal 4, courses.size
   end
 
+  test "#index returns child components and grades of a course" do
+    @user.courses.first.components.create!(name: 'Tests', weight: 20).grades.create!(name: 'Test 1', score: 10, max: 10)
+
+        get :index,
+      format: :json
+
+    assert_response 200
+    assert courses = JSON.parse(@response.body)
+    course = courses.first
+    assert_equal 1, course["components"].count
+    assert_equal 1, course["components"].first["grades"].count
+  end
+
   # SHOW
   test "#show returns the correct course with the correct attributes when the course exists" do
     new_course = @user.courses.create!(code: 'MATH 1004', name: 'Calculus 1')


### PR DESCRIPTION
### What
Currently, the client makes separate requests in each Angular controller for the appropriate array of objects.
As a result, something like this happens. 
```
CoursesController -> GET '/courses' => returns a list of 5 courses
In EACH course (CourseCardCtrl -> GET `/components' => returns 3 components per course)
In EACH component of EACH course (ComponentCardCtrl -> GET '/grades' => returns 5 grades)
Total: 1 + 5 + 15 = 21 http requests
```

### Changes
- JSON builder now returns nested objects to eliminate http requests for
nested objects.
- This should not break anything in the client since it now just returns
children as another attribute.

The above scenario becomes
```
CoursesController -> GET '/courses' => returns a list of 5 courses, each with 3 child components, which each have 5 child grades
Total: 1 http request
```

### Follow up
 - modify the client to take advantage of this return structure