### PR TITLE
Add viewport meta tag to improve layout on mobile

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
     <%= csrf_meta_tags %>
-    <!--Safari pinned tab icon (doesn't work yet)-->
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel='mask-icon' href='favicon2.svg' color='blue'>
     <%= favicon_link_tag 'fox_icon_no_bg.ico' %>
   </head>


### PR DESCRIPTION
Mobile view renders at native resolution, not taking advantage of responsiveness.
Add the tag:
`<meta name="viewport" content="width=device-width, initial-scale=1.0">`
to `application.html.erb`.