### PR TITLE
Root to sign in page if not signed in

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -9,7 +9,7 @@
           <span class="icon-bar"></span>
         </button>
         <%= image_tag "fox_icon_no_bg.png", class: "brand-image" %>
-        <%= link_to "GradePal", root_path, :class => "navbar-brand pull-right"%>
+        <%= link_to "GradePal", user_signed_in? ? authenticated_root_path : unauthenticated_root_path, :class => "navbar-brand pull-right"%>
       </div>
       <div id="navbar" class="navbar-collapse collapse">
         <ul id="right-navbar" class="nav navbar-nav pull-right">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,15 @@
 Rails.application.routes.draw do
   devise_for :users
-  root 'home#index'
+
+  devise_scope :user do
+    authenticated :user do
+      root 'home#index', as: :authenticated_root
+    end
+
+    unauthenticated do
+      root 'devise/sessions#new', as: :unauthenticated_root
+    end
+  end
 
   resources :user
   resources :courses


### PR DESCRIPTION
### Before
Navigating to the root brings the user into the app view, but empty sections, since the user is not signed in. The user should not see this page unless they are signed in.
![image](https://cloud.githubusercontent.com/assets/4921652/22134629/80772008-de96-11e6-99b5-e794e6bbcd5c.png)

### After
Navigating to the root brings the user to:
- sign in page if not already signed in
- app page if already signed in
![image](https://cloud.githubusercontent.com/assets/4921652/22134670/d29632f2-de96-11e6-821b-537032ae9164.png)

