### PR TITLE
Add simple js window confirmation to delete actions

### DIFF
--- a/app/assets/javascripts/components/main/directives/component-card/componentCardCtrl.js
+++ b/app/assets/javascripts/components/main/directives/component-card/componentCardCtrl.js
@@ -49,11 +49,13 @@
     }
 
     ctrl.delete = function () {
-      console.log('Deleting component with id: ' + ctrl.component.id);
-      $http.delete('/components/'+ ctrl.component.id).then(function(){
-        $scope.$destroy();
-      });
-      $scope.gpCourseCtrl.removeComponent(ctrl.component.id);
+      if(window.confirm("Are you sure you want to delete '" + ctrl.component.name + "'?")){
+        console.log('Deleting component with id: ' + ctrl.component.id);
+        $http.delete('/components/'+ ctrl.component.id).then(function(){
+          $scope.$destroy();
+        });
+        $scope.gpCourseCtrl.removeComponent(ctrl.component.id);
+      }
     }
 
     ctrl.save = function () {

--- a/app/assets/javascripts/components/main/directives/component-card/partials/component-regular-view.html
+++ b/app/assets/javascripts/components/main/directives/component-card/partials/component-regular-view.html
@@ -6,5 +6,5 @@
 </span>
 <div style="display: inline-block" class="pull-right">
   <a href ng-click="ctrl.edit()">Edit</a>
-  <a href ng-click="ctrl.delete()">Delete</a>
+  <a href ng-click="ctrl.delete(); ctrl.toggleSelect()">Delete</a>
 </div>

--- a/app/assets/javascripts/components/main/directives/course-card/courseCardCtrl.js
+++ b/app/assets/javascripts/components/main/directives/course-card/courseCardCtrl.js
@@ -47,10 +47,12 @@
     }
 
     ctrl.delete = function () {
-      console.log('Deleting course with id: ' + $scope.gpCourse.id);
-      $http.delete('/courses/'+ $scope.gpCourse.id).then(function(){
-        $scope.gpParentCtrl.removeCourse($scope.gpCourse.id);
-      });
+      if(window.confirm("Are you sure you want to delete '" + $scope.gpCourse.code + " - " + $scope.gpCourse.name + "'?")){
+        console.log('Deleting course with id: ' + $scope.gpCourse.id);
+        $http.delete('/courses/'+ $scope.gpCourse.id).then(function(){
+          $scope.gpParentCtrl.removeCourse($scope.gpCourse.id);
+        });
+      }
     }
 
     ctrl.save = function () {


### PR DESCRIPTION
### Summary
This PR adds very basic confirmation to the `delete` buttons on courses and components (not grades).
It looks like this:
![image](https://cloud.githubusercontent.com/assets/4921652/22152489/301cc058-def1-11e6-8325-44595600f08b.png)

### Follow-up
Ideal solution is to implement an `undo` action after a course or component is deleted, and skip the confirmation dialog entirely.