### PR TITLE
Implement 'sticky footer'

### DIFF
--- a/app/assets/javascripts/components/main/directives/courses/courses-view.html
+++ b/app/assets/javascripts/components/main/directives/courses/courses-view.html
@@ -1,6 +1,6 @@
 <div class="wrapper">
   <header class="header">
-    <aside class="flash row">
+    <aside class="flash">
       <div flash-alert duration="3500" active-class="in alert" class="fade">
         <button type="button" class="close" ng-click="hide()">&times;</button>
         {{flash.message}}
@@ -29,5 +29,4 @@
     </section>
   </article>
   <!-- <aside class="aside aside-2">Aside 2</aside> -->
-  <footer class="footer"></footer>
 </div>

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -22,7 +22,20 @@ $threshold: 768px;
 $main-border: 2px solid #909090;
 $footer-background: #f0f0f0;
 
-html, body { height: 100%; }
+html {
+  height: 100%;
+}
+
+body {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.content {
+  flex: 1;
+  float: left;
+}
 
 .flex {
   display: flex;
@@ -53,15 +66,12 @@ html, body { height: 100%; }
 }
 
 footer {
-    position: absolute;
-    left: 0;
-    bottom: 0;
     height: 75px;
     width: 100%;
     background-color: $footer-background;
 
     #copyright-content{
-      margin: 30px 0px;
+      margin: 20px;
     }
 }
 

--- a/app/views/layouts/_app_page.html.erb
+++ b/app/views/layouts/_app_page.html.erb
@@ -1,7 +1,4 @@
-<div>
+<div class="app-page-wrapper">
   <%= render 'layouts/navbar' %>
-
   <%= yield %>
-
-  <%= render 'layouts/footer' %>
 </div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,5 +1,5 @@
 <footer class="translucent">
-    <div class="container">
-      <p id="copyright-content" class="pull-right">© 2016 GradePal</p>
-    </div>
+  <div>
+    <p id="copyright-content" class="pull-right">© 2016 GradePal</p>
+  </div>
 </footer>

--- a/app/views/layouts/_site_page.html.erb
+++ b/app/views/layouts/_site_page.html.erb
@@ -1,7 +1,4 @@
 <div class="site-page-wrapper">
   <%= render 'layouts/navbar' %>
-
   <%= yield %>
-
-  <%= render 'layouts/footer' %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,9 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="content">
+      <%= yield %>
+    </div>
+    <%= render 'layouts/footer' %>
   </body>
 </html>


### PR DESCRIPTION
This fixes the problem shown in the screenshot below.
<img src="https://cloud.githubusercontent.com/assets/4921652/22407130/744ead38-e62e-11e6-91e4-05d30f0a6141.png" width=300>

This is caused by absolute positioning.

Solution: Implement a 'sticky footer' with flexbox.

Footer stays at bottom of viewport if not enough content, but stays
under content if it passes the vertical height of the viewport, instead
of being positioned absolutely.

Also removes horizontal scrollbar due to negative margin on ‘row’ class
on flash aside.